### PR TITLE
logDebug => log.debug

### DIFF
--- a/devicetypes/darwinsden/tesla-powerwall.src/tesla-powerwall.groovy
+++ b/devicetypes/darwinsden/tesla-powerwall.src/tesla-powerwall.groovy
@@ -256,7 +256,7 @@ def refresh() {
 }
 
 def poll() {
-  logDebug "poll()"
+  log.debug "poll()"
   def status = parent.refresh(this)
 }
 


### PR DESCRIPTION
All the other instances use log.debug; this instance is throwing a groovy.lang.MissingMethodException.